### PR TITLE
Rsdev 476 load chemicals with obabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ doesn't exist.
 ## Chemistry Libraries
 The Indigo java library and OpenBabel linux library provide the chemistry functionality of this app.
 
-Indigo is used for conversion, extraction, and image generation, and OpenBabel is used for chemical search.
-
-This could be expanded further e.g. by using OpenBabel to attempt to read chemical formats that Indigo cannot.
+Indigo is used for conversion, extraction, and image generation, and OpenBabel is used for conversion and search.
 
 ## Functionality
 The app provides the following functionality:

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
       <artifactId>commons-io</artifactId>
       <version>2.17.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.16.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.8.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.17.0</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -65,6 +71,17 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+<!--      fix mockito warning about self-attaching agent-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            -Xshare:off
+          </argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>

--- a/src/main/java/com/researchspace/chemistry/ChemistryException.java
+++ b/src/main/java/com/researchspace/chemistry/ChemistryException.java
@@ -1,4 +1,4 @@
-package com.researchspace.chemistry.convert;
+package com.researchspace.chemistry;
 
 public class ChemistryException extends RuntimeException {
   public ChemistryException(String message, Exception cause) {

--- a/src/main/java/com/researchspace/chemistry/convert/ConvertDTO.java
+++ b/src/main/java/com/researchspace/chemistry/convert/ConvertDTO.java
@@ -2,4 +2,8 @@ package com.researchspace.chemistry.convert;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ConvertDTO(@NotNull String input, @NotNull String outputFormat) {}
+public record ConvertDTO(@NotNull String input, String inputFormat, @NotNull String outputFormat) {
+  public ConvertDTO(String input, String outputFormat) {
+    this(input, "", outputFormat);
+  }
+}

--- a/src/main/java/com/researchspace/chemistry/convert/ConvertService.java
+++ b/src/main/java/com/researchspace/chemistry/convert/ConvertService.java
@@ -1,7 +1,11 @@
 package com.researchspace.chemistry.convert;
 
+import com.researchspace.chemistry.ChemistryException;
+import com.researchspace.chemistry.convert.convertor.Convertor;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,13 +14,20 @@ public class ConvertService {
 
   private final Convertor convertor;
 
-  public ConvertService(Convertor convertor) {
+  public ConvertService(@Qualifier("CompositeConvertor") Convertor convertor) {
     this.convertor = convertor;
   }
 
   public String convert(ConvertDTO convertDTO) {
     LOGGER.info(
-        "Converting input: {} to output format: {}", convertDTO.input(), convertDTO.outputFormat());
-    return convertor.convert(convertDTO);
+        "Converting format: {} with input: {} to output format: {}",
+        convertDTO.inputFormat(),
+        convertDTO.input(),
+        convertDTO.outputFormat());
+    Optional<String> converted = convertor.convert(convertDTO);
+    return converted.orElseThrow(
+        () ->
+            new ChemistryException(
+                String.format("Unable to perform conversion to %s.", convertDTO.outputFormat())));
   }
 }

--- a/src/main/java/com/researchspace/chemistry/convert/ConvertService.java
+++ b/src/main/java/com/researchspace/chemistry/convert/ConvertService.java
@@ -14,7 +14,7 @@ public class ConvertService {
 
   private final Convertor convertor;
 
-  public ConvertService(@Qualifier("CompositeConvertor") Convertor convertor) {
+  public ConvertService(@Qualifier("compositeConvertor") Convertor convertor) {
     this.convertor = convertor;
   }
 

--- a/src/main/java/com/researchspace/chemistry/convert/Convertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/Convertor.java
@@ -1,6 +1,0 @@
-package com.researchspace.chemistry.convert;
-
-public interface Convertor {
-
-  String convert(ConvertDTO convertDTO);
-}

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
@@ -22,14 +22,9 @@ public class CompositeConvertor implements Convertor {
 
   @Override
   public Optional<String> convert(ConvertDTO convertDTO) {
-    Optional<String> converted;
-    if (canBeConvertedByOpenBabel(convertDTO.inputFormat())) {
+    Optional<String> converted = indigoConvertor.convert(convertDTO);
+    if (converted.isEmpty() && canBeConvertedByOpenBabel(convertDTO.inputFormat())) {
       converted = openBabelConvertor.convert(convertDTO);
-      if (converted.isEmpty()) {
-        converted = indigoConvertor.convert(convertDTO);
-      }
-    } else {
-      converted = indigoConvertor.convert(convertDTO);
     }
     return converted;
   }

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
@@ -1,0 +1,41 @@
+package com.researchspace.chemistry.convert.convertor;
+
+import com.researchspace.chemistry.convert.ConvertDTO;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service("CompositeConvertor")
+public class CompositeConvertor implements Convertor {
+  private final Convertor openBabelConvertor;
+
+  private final Convertor indigoConvertor;
+
+  @Autowired
+  public CompositeConvertor(
+      @Qualifier("OpenBabelConvertor") Convertor openBabel,
+      @Qualifier("IndigoConvertor") Convertor indigo) {
+    this.openBabelConvertor = openBabel;
+    this.indigoConvertor = indigo;
+  }
+
+  @Override
+  public Optional<String> convert(ConvertDTO convertDTO) {
+    Optional<String> converted;
+    if (canBeConvertedByOpenBabel(convertDTO.inputFormat())) {
+      converted = openBabelConvertor.convert(convertDTO);
+      if (converted.isEmpty()) {
+        converted = indigoConvertor.convert(convertDTO);
+      }
+    } else {
+      converted = indigoConvertor.convert(convertDTO);
+    }
+    return converted;
+  }
+
+  // OpenBabel needs to know the input format before attempting conversion
+  private boolean canBeConvertedByOpenBabel(String inputFormat) {
+    return inputFormat != null && !inputFormat.isEmpty();
+  }
+}

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/CompositeConvertor.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-@Service("CompositeConvertor")
+@Service
 public class CompositeConvertor implements Convertor {
   private final Convertor openBabelConvertor;
 
@@ -14,8 +14,8 @@ public class CompositeConvertor implements Convertor {
 
   @Autowired
   public CompositeConvertor(
-      @Qualifier("OpenBabelConvertor") Convertor openBabel,
-      @Qualifier("IndigoConvertor") Convertor indigo) {
+      @Qualifier("openBabelConvertor") Convertor openBabel,
+      @Qualifier("indigoConvertor") Convertor indigo) {
     this.openBabelConvertor = openBabel;
     this.indigoConvertor = indigo;
   }

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/Convertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/Convertor.java
@@ -1,0 +1,9 @@
+package com.researchspace.chemistry.convert.convertor;
+
+import com.researchspace.chemistry.convert.ConvertDTO;
+import java.util.Optional;
+
+public interface Convertor {
+
+  Optional<String> convert(ConvertDTO convertDTO);
+}

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/IndigoConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/IndigoConvertor.java
@@ -1,9 +1,11 @@
-package com.researchspace.chemistry.convert;
+package com.researchspace.chemistry.convert.convertor;
 
+import com.researchspace.chemistry.convert.ConvertDTO;
 import com.researchspace.chemistry.util.IndigoFacade;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 
-@Service
+@Service("IndigoConvertor")
 public class IndigoConvertor implements Convertor {
   private final IndigoFacade indigo;
 
@@ -12,7 +14,7 @@ public class IndigoConvertor implements Convertor {
   }
 
   @Override
-  public String convert(ConvertDTO convertDTO) throws ChemistryException {
+  public Optional<String> convert(ConvertDTO convertDTO) {
     return indigo.convert(convertDTO);
   }
 }

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/IndigoConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/IndigoConvertor.java
@@ -5,7 +5,7 @@ import com.researchspace.chemistry.util.IndigoFacade;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
-@Service("IndigoConvertor")
+@Service
 public class IndigoConvertor implements Convertor {
   private final IndigoFacade indigo;
 

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertor.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.springframework.stereotype.Service;
 
-@Service("OpenBabelConvertor")
+@Service
 public class OpenBabelConvertor implements Convertor {
   public static final String OPENBABEL_ERROR_OUTPUT_IDENTIFIER = "Open Babel 3.1.0 -- ";
 

--- a/src/main/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertor.java
+++ b/src/main/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertor.java
@@ -1,0 +1,45 @@
+package com.researchspace.chemistry.convert.convertor;
+
+import com.researchspace.chemistry.ChemistryException;
+import com.researchspace.chemistry.convert.ConvertDTO;
+import com.researchspace.chemistry.util.CommandExecutor;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.springframework.stereotype.Service;
+
+@Service("OpenBabelConvertor")
+public class OpenBabelConvertor implements Convertor {
+  public static final String OPENBABEL_ERROR_OUTPUT_IDENTIFIER = "Open Babel 3.1.0 -- ";
+
+  private final CommandExecutor commandExecutor;
+
+  public OpenBabelConvertor(CommandExecutor commandExecutor) {
+    this.commandExecutor = commandExecutor;
+  }
+
+  @Override
+  public Optional<String> convert(ConvertDTO convertDTO) {
+    try {
+      File tempFile = File.createTempFile("temp-", ".tmp");
+      Files.write(tempFile.toPath(), convertDTO.input().getBytes());
+      ProcessBuilder builder = new ProcessBuilder();
+      builder.command(
+          "obabel",
+          "-i" + convertDTO.inputFormat(),
+          tempFile.getAbsolutePath(),
+          "-o" + convertDTO.outputFormat());
+      String output = String.join("\n", commandExecutor.executeCommand(builder));
+      Files.delete(tempFile.toPath());
+      if (output.isEmpty() || output.startsWith(OPENBABEL_ERROR_OUTPUT_IDENTIFIER)) {
+        return Optional.empty();
+      }
+      return Optional.of(output);
+    } catch (IOException | ExecutionException | InterruptedException | TimeoutException e) {
+      throw new ChemistryException("Problem while converting.", e);
+    }
+  }
+}

--- a/src/main/java/com/researchspace/chemistry/extract/IndigoExtractor.java
+++ b/src/main/java/com/researchspace/chemistry/extract/IndigoExtractor.java
@@ -31,7 +31,7 @@ public class IndigoExtractor implements Extractor {
     result.setFormula(formula);
     result.setReaction(isReaction);
     // for reactions, only the formula is displayed
-    if(isReaction) {
+    if (isReaction) {
       return result;
     }
 
@@ -41,8 +41,8 @@ public class IndigoExtractor implements Extractor {
     double mass = tryDoubleOperation(inputChemical::mostAbundantMass);
     double molWeight = tryDoubleOperation(inputChemical::molecularWeight);
 
-
-    molecules.add(new Molecule.Builder()
+    molecules.add(
+        new Molecule.Builder()
             .atomCount(atomCount)
             .bondCount(bondCount)
             .exactMass(mass)

--- a/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
+++ b/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
@@ -4,7 +4,7 @@ import com.epam.indigo.Indigo;
 import com.epam.indigo.IndigoException;
 import com.epam.indigo.IndigoObject;
 import com.epam.indigo.IndigoRenderer;
-import com.researchspace.chemistry.convert.ChemistryException;
+import com.researchspace.chemistry.ChemistryException;
 import com.researchspace.chemistry.util.IndigoFacade;
 import java.awt.*;
 import java.awt.image.BufferedImage;

--- a/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
+++ b/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
@@ -6,7 +6,8 @@ import com.epam.indigo.IndigoObject;
 import com.epam.indigo.IndigoRenderer;
 import com.researchspace.chemistry.ChemistryException;
 import com.researchspace.chemistry.util.IndigoFacade;
-import java.awt.*;
+
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
+++ b/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
@@ -6,7 +6,6 @@ import com.epam.indigo.IndigoObject;
 import com.epam.indigo.IndigoRenderer;
 import com.researchspace.chemistry.ChemistryException;
 import com.researchspace.chemistry.util.IndigoFacade;
-
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -7,8 +7,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -1,13 +1,12 @@
 package com.researchspace.chemistry.search;
 
+import com.researchspace.chemistry.util.CommandExecutor;
 import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,12 +14,10 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +37,14 @@ public class SearchService {
 
   private File index;
 
-  final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  private CommandExecutor commandExecutor;
+
+  @Autowired
+  public SearchService(CommandExecutor commandExecutor) {
+    this.commandExecutor = commandExecutor;
+  }
 
   @PostConstruct
   public void initFiles() throws IOException {
@@ -69,7 +73,7 @@ public class SearchService {
     }
   }
 
-  //TODO: sanitise searchTerm
+  // TODO: sanitise searchTerm
   public List<String> searchNonIndexedFile(String searchTerm)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     ProcessBuilder builder = new ProcessBuilder();
@@ -78,7 +82,7 @@ public class SearchService {
     LOGGER.info(
         "Searching without index for {} in file: {}", searchTerm, nonIndexedChemicals.getPath());
     LOGGER.info("FOUND:");
-    return executeCommand(builder);
+    return commandExecutor.executeCommand(builder);
   }
 
   public List<String> searchIndexedFile(String searchTerm)
@@ -86,22 +90,7 @@ public class SearchService {
     ProcessBuilder builder = new ProcessBuilder();
     builder.command("obabel", index.getPath(), "-s" + searchTerm, "-o" + format, "-xt");
     LOGGER.info("Searching with index for {} in file: {}", searchTerm, indexedChemicals.getPath());
-    return executeCommand(builder);
-  }
-
-  private List<String> executeCommand(ProcessBuilder builder)
-      throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    LOGGER.info("Executing command: {}", builder.command());
-    builder.directory(null); // uses current working directory
-    Process process = builder.start();
-    List<String> matches = new ArrayList<>();
-    InputStreamConsumer streamConsumer =
-        new InputStreamConsumer(process.getInputStream(), matches::add);
-    Future<?> future = executorService.submit(streamConsumer);
-    process.waitFor();
-    future.get(10, TimeUnit.SECONDS);
-    LOGGER.info("Found matches: {}", String.join(", ", matches));
-    return matches;
+    return commandExecutor.executeCommand(builder);
   }
 
   // not currently configured
@@ -128,7 +117,7 @@ public class SearchService {
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
     ProcessBuilder builder = new ProcessBuilder();
     builder.command("obabel", indexedChemicals.getPath(), "-O" + index.getPath());
-    executeCommand(builder);
+    commandExecutor.executeCommand(builder);
   }
 
   public List<String> search(String chemicalSearchTerm)
@@ -140,17 +129,5 @@ public class SearchService {
       return hits;
     }
     return Collections.emptyList();
-  }
-
-  /***
-   * Perform an action on each line of an input stream
-   */
-  private record InputStreamConsumer(InputStream inputStream, Consumer<String> consumer)
-      implements Runnable {
-
-    @Override
-    public void run() {
-      new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
-    }
   }
 }

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -73,7 +73,6 @@ public class SearchService {
     }
   }
 
-  // TODO: sanitise searchTerm
   public List<String> searchNonIndexedFile(String searchTerm)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     ProcessBuilder builder = new ProcessBuilder();

--- a/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
+++ b/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
@@ -1,0 +1,53 @@
+package com.researchspace.chemistry.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommandExecutor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommandExecutor.class);
+
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  public List<String> executeCommand(ProcessBuilder processBuilder)
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    LOGGER.info("Executing command: {}", processBuilder.command());
+    processBuilder.directory(null); // uses current working directory
+    Process process = processBuilder.start();
+    List<String> output = new ArrayList<>();
+    InputStreamConsumer streamConsumer =
+        new InputStreamConsumer(process.getInputStream(), output::add);
+    Future<?> future = executorService.submit(streamConsumer);
+    process.waitFor();
+    future.get(10, TimeUnit.SECONDS);
+    LOGGER.info("Found output: {}", String.join(", ", output));
+    return output;
+  }
+
+  /***
+   * Perform an action on each line of an input stream
+   */
+  private record InputStreamConsumer(InputStream inputStream, Consumer<String> consumer)
+      implements Runnable {
+
+    @Override
+    public void run() {
+      new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+    }
+  }
+}

--- a/src/main/java/com/researchspace/chemistry/util/IndigoFacade.java
+++ b/src/main/java/com/researchspace/chemistry/util/IndigoFacade.java
@@ -29,7 +29,7 @@ public class IndigoFacade {
         return Optional.empty();
       }
       return Optional.of(converted);
-    } catch (IndigoException e) {
+    } catch (ChemistryException e) {
       return Optional.empty();
     }
   }

--- a/src/main/java/com/researchspace/chemistry/util/IndigoFacade.java
+++ b/src/main/java/com/researchspace/chemistry/util/IndigoFacade.java
@@ -6,10 +6,13 @@ import com.epam.indigo.IndigoObject;
 import com.researchspace.chemistry.ChemistryException;
 import com.researchspace.chemistry.convert.ConvertDTO;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class IndigoFacade {
+  private static final Logger logger = LoggerFactory.getLogger(IndigoFacade.class);
 
   public Optional<String> convert(ConvertDTO convertDTO) {
     Indigo indigo = new Indigo();
@@ -20,16 +23,19 @@ public class IndigoFacade {
       indigoObject = load(indigo, convertDTO.input());
       String converted =
           switch (convertDTO.outputFormat()) {
+            case "cdx" -> indigoObject.b64cdx();
             case "cdxml" -> indigoObject.cdxml();
             case "smiles" -> indigoObject.smiles();
             case "ket" -> indigoObject.json();
+            case "mol" -> indigoObject.molfile();
             default -> "";
           };
       if (converted.isEmpty()) {
         return Optional.empty();
       }
       return Optional.of(converted);
-    } catch (ChemistryException e) {
+    } catch (ChemistryException | IndigoException e) {
+      logger.warn("Unable to convert with Indigo. {}", e.getMessage());
       return Optional.empty();
     }
   }

--- a/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
+++ b/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
@@ -27,7 +27,7 @@ public class ConvertServiceIT {
 
   @Autowired ConvertService convertService;
 
-  private static final String VALID_CDXML_START = "<?xml version=\"1.0\"?>\n<!DOCTYPE CDXML";
+  private static final String VALID_CDXML_START = "<?xml version=\"1.0\"";
 
   @Test
   public void whenValidRequest_thenConversionIsSuccessful() {
@@ -70,7 +70,7 @@ public class ConvertServiceIT {
             });
 
     assertEquals(
-        "Can't load input as molecule or reaction. Input: not-smiles", exception.getMessage());
+        "Unable to perform conversion to cdxml.", exception.getMessage());
   }
 
   @Disabled("Some files fail to be converted")
@@ -111,7 +111,7 @@ public class ConvertServiceIT {
   }
 
   private static List<ConvertDTO> readFiles(String outputFormat) throws Exception {
-    try (Stream<Path> paths = Files.walk(Paths.get("src/test/resources"))) {
+    try (Stream<Path> paths = Files.walk(Paths.get("src/test/resources/chemistry_files"))) {
       return paths
           .filter(Files::isRegularFile)
           .filter(path -> !path.toString().endsWith(".cdx"))

--- a/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
+++ b/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -69,8 +70,7 @@ public class ConvertServiceIT {
               convertService.convert(convertDTO);
             });
 
-    assertEquals(
-        "Unable to perform conversion to cdxml.", exception.getMessage());
+    assertEquals("Unable to perform conversion to cdxml.", exception.getMessage());
   }
 
   @Disabled("Some files fail to be converted")
@@ -114,12 +114,13 @@ public class ConvertServiceIT {
     try (Stream<Path> paths = Files.walk(Paths.get("src/test/resources/chemistry_files"))) {
       return paths
           .filter(Files::isRegularFile)
-          .filter(path -> !path.toString().endsWith(".cdx"))
           .map(
               path -> {
                 try {
                   return new ConvertDTO(
-                      Files.readString(path),
+                      path.toString().endsWith(".cdx")
+                          ? Base64.getEncoder().encodeToString(Files.readAllBytes(path))
+                          : Files.readString(path),
                       FilenameUtils.getExtension(path.toString()),
                       outputFormat);
                 } catch (IOException e) {

--- a/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
+++ b/src/test/java/com/researchspace/chemistry/convert/ConvertServiceIT.java
@@ -73,7 +73,7 @@ public class ConvertServiceIT {
         "Can't load input as molecule or reaction. Input: not-smiles", exception.getMessage());
   }
 
-  @Disabled
+  @Disabled("Some files fail to be converted")
   @ParameterizedTest
   @MethodSource("readFilesForCdxmlConversion")
   public void whenValidChemicalFile_thenConversionToCdxmlIsSuccessful(ConvertDTO convertDTO) {
@@ -81,7 +81,7 @@ public class ConvertServiceIT {
     assertTrue(result.contains(VALID_CDXML_START));
   }
 
-  @Disabled
+  @Disabled("Some files fail to be converted")
   @ParameterizedTest
   @MethodSource("readFilesForSmilesConversion")
   public void whenValidChemicalFile_thenConversionToSmilesIsSuccessful(ConvertDTO convertDTO) {
@@ -89,7 +89,7 @@ public class ConvertServiceIT {
     assertTrue(result.contains("C"));
   }
 
-  @Disabled
+  @Disabled("Some files fail to be converted")
   @ParameterizedTest
   @MethodSource("readFilesForKetConversion")
   public void whenValidChemicalFile_thenConversionToKetIsSuccessful(ConvertDTO convertDTO) {

--- a/src/test/java/com/researchspace/chemistry/convert/convertor/CompositeConvertorTest.java
+++ b/src/test/java/com/researchspace/chemistry/convert/convertor/CompositeConvertorTest.java
@@ -45,26 +45,26 @@ public class CompositeConvertorTest {
   }
 
   @Test
-  public void whenInputFormatSupplied_tryOpenBabelFirst() {
+  public void whenInputFormatSupplied_tryIndigoFirst() {
     ConvertDTO input = new ConvertDTO("aChemical", "anInputFormat", "anOutputFormat");
     String expected = "C";
 
-    when(openBabelConvertor.convert(any())).thenReturn(Optional.of(expected));
+    when(indigoConvertor.convert(any())).thenReturn(Optional.of(expected));
 
     String actual = compositeConvertor.convert(input).get();
 
     assertEquals(expected, actual);
-    Mockito.verify(openBabelConvertor, times(1)).convert(any());
-    Mockito.verify(indigoConvertor, never()).convert(any());
+    Mockito.verify(indigoConvertor, times(1)).convert(any());
+    Mockito.verify(openBabelConvertor, never()).convert(any());
   }
 
   @Test
-  public void whenNotConvertedByOpenBabel_thenConvertWithIndigo() {
+  public void whenNotConvertedByIndigo_thenConvertWithOpenBabel() {
     ConvertDTO input = new ConvertDTO("aChemical", "anInputFormat", "anOutputFormat");
     String expected = "C";
 
-    when(openBabelConvertor.convert(any())).thenReturn(Optional.empty());
-    when(indigoConvertor.convert(any())).thenReturn(Optional.of(expected));
+    when(indigoConvertor.convert(any())).thenReturn(Optional.empty());
+    when(openBabelConvertor.convert(any())).thenReturn(Optional.of(expected));
 
     String actual = compositeConvertor.convert(input).get();
 

--- a/src/test/java/com/researchspace/chemistry/convert/convertor/CompositeConvertorTest.java
+++ b/src/test/java/com/researchspace/chemistry/convert/convertor/CompositeConvertorTest.java
@@ -1,0 +1,89 @@
+package com.researchspace.chemistry.convert.convertor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.chemistry.convert.ConvertDTO;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CompositeConvertorTest {
+
+  @Mock OpenBabelConvertor openBabelConvertor;
+  @Mock IndigoConvertor indigoConvertor;
+
+  CompositeConvertor compositeConvertor;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    compositeConvertor = new CompositeConvertor(openBabelConvertor, indigoConvertor);
+  }
+
+  @Test
+  public void whenEmptyInputFormat_thenUseIndigoConvertor() {
+    ConvertDTO input = new ConvertDTO("aChemical", "aFormat");
+    String expected = "C";
+
+    when(indigoConvertor.convert(any())).thenReturn(Optional.of(expected));
+
+    String actual = compositeConvertor.convert(input).get();
+
+    assertEquals(expected, actual);
+    Mockito.verify(indigoConvertor, times(1)).convert(any());
+    Mockito.verify(openBabelConvertor, times(0)).convert(any());
+  }
+
+  @Test
+  public void whenInputFormatSupplied_tryOpenBabelFirst() {
+    ConvertDTO input = new ConvertDTO("aChemical", "anInputFormat", "anOutputFormat");
+    String expected = "C";
+
+    when(openBabelConvertor.convert(any())).thenReturn(Optional.of(expected));
+
+    String actual = compositeConvertor.convert(input).get();
+
+    assertEquals(expected, actual);
+    Mockito.verify(openBabelConvertor, times(1)).convert(any());
+    Mockito.verify(indigoConvertor, never()).convert(any());
+  }
+
+  @Test
+  public void whenNotConvertedByOpenBabel_thenConvertWithIndigo() {
+    ConvertDTO input = new ConvertDTO("aChemical", "anInputFormat", "anOutputFormat");
+    String expected = "C";
+
+    when(openBabelConvertor.convert(any())).thenReturn(Optional.empty());
+    when(indigoConvertor.convert(any())).thenReturn(Optional.of(expected));
+
+    String actual = compositeConvertor.convert(input).get();
+
+    assertEquals(expected, actual);
+    Mockito.verify(openBabelConvertor, times(1)).convert(any());
+    Mockito.verify(indigoConvertor, times(1)).convert(any());
+  }
+
+  @Test
+  public void whenNotConvertedByEitherConvertor_thenReturnEmptyOptional() {
+    ConvertDTO input = new ConvertDTO("aChemical", "anInputFormat", "anOutputFormat");
+
+    when(openBabelConvertor.convert(any())).thenReturn(Optional.empty());
+    when(indigoConvertor.convert(any())).thenReturn(Optional.empty());
+
+    Optional<String> actual = compositeConvertor.convert(input);
+
+    assertEquals(Optional.empty(), actual);
+    Mockito.verify(openBabelConvertor, times(1)).convert(any());
+    Mockito.verify(indigoConvertor, times(1)).convert(any());
+  }
+}

--- a/src/test/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertorTest.java
+++ b/src/test/java/com/researchspace/chemistry/convert/convertor/OpenBabelConvertorTest.java
@@ -1,0 +1,85 @@
+package com.researchspace.chemistry.convert.convertor;
+
+import static com.researchspace.chemistry.convert.convertor.OpenBabelConvertor.OPENBABEL_ERROR_OUTPUT_IDENTIFIER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.chemistry.ChemistryException;
+import com.researchspace.chemistry.convert.ConvertDTO;
+import com.researchspace.chemistry.util.CommandExecutor;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenBabelConvertorTest {
+
+  @Mock CommandExecutor commandExecutor;
+
+  @InjectMocks OpenBabelConvertor convertor;
+
+  @Test
+  public void whenSuccessfulConversion_thenReturnResults() throws Exception {
+    String expected = "C";
+    when(commandExecutor.executeCommand(any())).thenReturn(List.of(expected));
+
+    Optional<String> actual = convertor.convert(new ConvertDTO("someInput", "someFormat"));
+
+    assertEquals(expected, actual.get());
+  }
+
+  @Test
+  public void whenMultiLineOutput_thenStringJoinedWithNewLine() throws Exception {
+    when(commandExecutor.executeCommand(any())).thenReturn(List.of("C", "CC"));
+
+    String expected = "C\nCC";
+    Optional<String> actual = convertor.convert(new ConvertDTO("someInput", "someFormat"));
+
+    assertEquals(expected, actual.get());
+  }
+
+  @Test
+  public void whenNoOutputFromOpenBabel_thenReturnEmpty() throws Exception {
+    when(commandExecutor.executeCommand(any())).thenReturn(Collections.emptyList());
+
+    Optional<String> actual = convertor.convert(new ConvertDTO("someInput", "someFormat"));
+
+    assertEquals(Optional.empty(), actual);
+  }
+
+  @Test
+  public void whenErrorOutputFromOpenBabel_thenReturnEmpty() throws Exception {
+    when(commandExecutor.executeCommand(any()))
+        .thenReturn(List.of(OPENBABEL_ERROR_OUTPUT_IDENTIFIER));
+
+    String expected = "C\nCC";
+    Optional<String> actual = convertor.convert(new ConvertDTO("someInput", "someFormat"));
+
+    assertEquals(Optional.empty(), actual);
+  }
+
+  @Test
+  public void whenExceptionThrownFromOpenBabel_thenWrapWithChemistryException() throws Exception {
+    String ioExceptionMessage = "Problem accessing OpenBabel";
+    when(commandExecutor.executeCommand(any())).thenThrow(new IOException(ioExceptionMessage));
+
+    ChemistryException exception =
+        assertThrows(
+            ChemistryException.class,
+            () -> {
+              ConvertDTO convertDTO = new ConvertDTO("not-smiles", "cdxml");
+              convertor.convert(convertDTO);
+            });
+
+    assertEquals("Problem while converting.", exception.getMessage());
+    assertEquals(ioExceptionMessage, exception.getCause().getMessage());
+  }
+}

--- a/src/test/java/com/researchspace/chemistry/extract/IndigoExtractorTest.java
+++ b/src/test/java/com/researchspace/chemistry/extract/IndigoExtractorTest.java
@@ -3,7 +3,7 @@ package com.researchspace.chemistry.extract;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.researchspace.chemistry.convert.ChemistryException;
+import com.researchspace.chemistry.ChemistryException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;

--- a/src/test/java/com/researchspace/chemistry/image/IndigoImageGeneratorIT.java
+++ b/src/test/java/com/researchspace/chemistry/image/IndigoImageGeneratorIT.java
@@ -3,7 +3,7 @@ package com.researchspace.chemistry.image;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.researchspace.chemistry.convert.ChemistryException;
+import com.researchspace.chemistry.ChemistryException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
This PR adds conversion using OpenBabel, in addition to Indigo which was already implemented.

OpenBabel needs to know the file format of the input type, which can be optionally provided. 

~~In the case where it is provided, we attempt conversion with OpenBabel first since it has a higher success rate with [these test files](https://github.com/ResearchSpace-ELN/chemistry-chemaxon/tree/master/src/test/resources/TestResources/Rob_Chemistry_examples)~~
[Edit: I've changed the code to attempt conversion using Indigo first, rather than OpenBabel, as many of the conversions are to/from the `.ket` format, which OpenBabel cannot handle. OpenBabel conversion is still attempted though when Indigo fails]

A further improvement could be to separate reading and converting/writing chemicals. E.g. OpenBabel can't read or write the `.ket` (ketcher) format, but might be able to read the e.g. `.cdxml` file with a higher success rate. OpenBabel could convert `.cdxml` to e.g. smiles, the Indigo could convert smiles to `.ket`. I've made a note of this as something we could look at further down the line.

Related `rspace-web-closed-source` PR: https://github.com/ResearchSpace-ELN/rspace-web-closed-source/pull/11

**Testing**
`ConvertServiceIT` has 3 tests which are `@Disabled` as I'm still unsure whether we can commit all of [these files](https://github.com/ResearchSpace-ELN/chemistry-chemaxon/tree/master/src/test/resources/TestResources/Rob_Chemistry_Examples) to an open-source repo (waiting to hear back from Rob). 

To run these tests locally, copy the files from the above link (and/or any other chemistry files) to `src/test/resources/chemistry_files` and comment the `@Disabled` annotations. 

The `@Qualifier` in the `ConvertService` constructor can be changed between `compositeConvertor`, `indigoConvertor` and `openBabelConvertor` to see the difference between the 3. (The test outputting to `.ket` format doesn't improve by using the `compositeConvertor` since OpenBabel cannot handle `.ket` format.)