### PR TITLE
rsdev-489 Fix image sizes

### DIFF
--- a/src/main/java/com/researchspace/chemistry/image/ImageDTO.java
+++ b/src/main/java/com/researchspace/chemistry/image/ImageDTO.java
@@ -2,4 +2,5 @@ package com.researchspace.chemistry.image;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ImageDTO(@NotNull String input, @NotNull String outputFormat) {}
+public record ImageDTO(
+    @NotNull String input, @NotNull String outputFormat, String width, String height) {}

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -69,7 +69,7 @@ public class SearchService {
     }
   }
 
-  //TODO: sanitise searchTerm
+  // TODO: sanitise searchTerm
   public List<String> searchNonIndexedFile(String searchTerm)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     ProcessBuilder builder = new ProcessBuilder();

--- a/src/test/java/com/researchspace/chemistry/image/IndigoImageGeneratorIT.java
+++ b/src/test/java/com/researchspace/chemistry/image/IndigoImageGeneratorIT.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.researchspace.chemistry.convert.ChemistryException;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,15 +22,39 @@ public class IndigoImageGeneratorIT {
   @ParameterizedTest
   @ValueSource(strings = {"png", "svg", "jpg", "jpeg"})
   public void whenValidImageFormat_thenImageGenerated(String format) {
-    ImageDTO imageDTO = new ImageDTO("CCC", format);
+    ImageDTO imageDTO = new ImageDTO("CCC", format, "100", "100");
     byte[] image = imageGenerator.generateImage(imageDTO);
     assert image.length > 0;
+  }
+
+  @Test
+  public void whenImageSizeProvided_thenImageSizeIsCorrect() throws Exception {
+    int imageWidthAndHeight = 100;
+    ImageDTO imageDTO =
+        new ImageDTO(
+            "CCC", "png", String.valueOf(imageWidthAndHeight), String.valueOf(imageWidthAndHeight));
+    byte[] bytes = imageGenerator.generateImage(imageDTO);
+    BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+    assertEquals(imageWidthAndHeight, image.getWidth());
+    assertEquals(imageWidthAndHeight, image.getHeight());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  public void whenNoSizeProvided_thenUseDefaultImageSize(String imageWidthAndHeight)
+      throws Exception {
+    int defaultWidthAndHeight = 500;
+    ImageDTO imageDTO = new ImageDTO("CCC", "png", imageWidthAndHeight, imageWidthAndHeight);
+    byte[] bytes = imageGenerator.generateImage(imageDTO);
+    BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+    assertEquals(defaultWidthAndHeight, image.getWidth());
+    assertEquals(defaultWidthAndHeight, image.getHeight());
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"gif", "txt", "pdf"})
   public void whenInvalidImageFormat_thenThrowException(String format) {
-    ImageDTO imageDTO = new ImageDTO("CCC", format);
+    ImageDTO imageDTO = new ImageDTO("CCC", format, "100", "100");
     ChemistryException exception =
         assertThrows(ChemistryException.class, () -> imageGenerator.generateImage(imageDTO));
     assertEquals("Unsupported image format: " + format, exception.getMessage());
@@ -35,7 +63,7 @@ public class IndigoImageGeneratorIT {
   @ParameterizedTest
   @NullAndEmptySource
   public void whenNullOrEmptyImageFormat_thenThrowException(String format) {
-    ImageDTO imageDTO = new ImageDTO("CCC", format);
+    ImageDTO imageDTO = new ImageDTO("CCC", format, "100", "100");
     ChemistryException exception =
         assertThrows(ChemistryException.class, () -> imageGenerator.generateImage(imageDTO));
     assertEquals("Output format is empty", exception.getMessage());


### PR DESCRIPTION
Images generated from chemical files were hard-coded and low-quality.

This PR takes the image width and height as config, as is done for existing chemistry. If these aren't provided, a default size is used. 

Accompanying `rspace-web-closed-source` PR: https://github.com/ResearchSpace-ELN/rspace-web-closed-source/pull/10 