### PR TITLE
Prt 897 dont layout images

### DIFF
--- a/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
+++ b/src/main/java/com/researchspace/chemistry/image/IndigoImageGenerator.java
@@ -74,7 +74,6 @@ public class IndigoImageGenerator implements ImageGenerator {
     indigo.setOption("render-output-format", imageDTO.outputFormat());
     indigo.setOption("render-margins", 10, 10);
     indigo.setOption("render-image-size", generateImageSize(imageDTO));
-    indigoObject.layout();
     try {
       return renderer.renderToBuffer(indigoObject);
     } catch (IndigoException e) {

--- a/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
+++ b/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
@@ -13,6 +13,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -35,7 +37,7 @@ public class CommandExecutor {
     Future<?> future = executorService.submit(streamConsumer);
     process.waitFor();
     future.get(30, TimeUnit.SECONDS);
-    LOGGER.info("Found output: {}", String.join(", ", output));
+    LOGGER.info("Found output: {}", StringUtils.abbreviate(String.join(", ", output), 500));
     return output;
   }
 


### PR DESCRIPTION
A pdb file with a complex image was failing to upload due to the call `indigoObject.layout()`. Layout tidies up the molecules on screen, but was failing silently for this complex image.

I think this is a good change in general, since I'd noticed that after saving a chemical drawn on Ketcher, the image would have elements repositioned. I thought this was due to some conversion or the way images were generated, but it was down to this call. Removing the `layout` call means the images generated more closely match the input.

I also truncated a potentially long log statement to clear up the logs.

input on ketcher:
<img width="1286" alt="Screenshot 2025-03-06 at 14 36 39" src="https://github.com/user-attachments/assets/0e51ab0a-12b2-414d-b119-5263b43288a8" />

image generated calling `layout()`:
<img width="278" alt="Screenshot 2025-03-06 at 14 36 47" src="https://github.com/user-attachments/assets/1bb5b45b-4243-415c-a263-4e204a902500" />

image generated after removing `layout()` call:
<img width="252" alt="Screenshot 2025-03-06 at 14 37 05" src="https://github.com/user-attachments/assets/75bb5585-7b07-4889-b2ac-280636d3640b" />


