### PR TITLE
use latest version of indigo library. set chemistry app version to 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.github.rspace-os</groupId>
   <artifactId>chemistry</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>chemistry</name>
   <description>chemistry</description>
   <url/>
@@ -33,13 +33,13 @@
     <dependency>
       <groupId>com.epam.indigo</groupId>
       <artifactId>indigo</artifactId>
-      <version>1.23.0-dev.3</version>
+      <version>1.30.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.epam.indigo</groupId>
       <artifactId>indigo-renderer</artifactId>
-      <version>1.23.0-dev.3</version>
+      <version>1.30.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There have been a few releases of the indigo library since the one we were using. I've tested the various functionality and there are improvements in conversions:
- 4 additional successful conversions in `ConvertServiceIT`
- 1 additional image (3 still don't generate) when importing all files from `src/test/resources` into the gallery.

I also bumped the version of the chemistry app which hasn't been updated so far but should start to be now.