### PR TITLE
PRT-896 meta information not showing

### DIFF
--- a/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
+++ b/src/main/java/com/researchspace/chemistry/util/CommandExecutor.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
When openbabel cannot convert, it prints some text starting with the version number of openbabel. The string to look for was hard-coded to `Open Babel 3.1.0 --` so when a patch upgrade changed the output to `Open Babel 3.1.1 --`, the output was no longer identified as a failure to convert and was therefore treated as the conversion result.

This change checks for output matching version 3.x.x. 

Also adds a PostConstruct check on the OpenBabel convertor to the library version installed is 3.x.x for compatibility.