### PR TITLE
RSDEV-360: add /chemistry/clearSearchIndexes endpoint 

### DIFF
--- a/src/main/java/com/researchspace/chemistry/search/SearchController.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchController.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -19,9 +20,10 @@ public class SearchController {
     this.searchService = searchService;
   }
 
-  @PostMapping(value = "/chemistry/clearSearchIndexes")
+  @DeleteMapping(value = "/chemistry/clearSearchIndexes")
   public @ResponseBody String clearSearchIndexes() throws IOException {
-    return searchService.clearIndexFiles();
+    searchService.clearIndexFiles();
+    return "Cleared";
   }
 
   @PostMapping(value = "/chemistry/save")

--- a/src/main/java/com/researchspace/chemistry/search/SearchController.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchController.java
@@ -19,6 +19,11 @@ public class SearchController {
     this.searchService = searchService;
   }
 
+  @PostMapping(value = "/chemistry/clearSearchIndexes")
+  public @ResponseBody String clearSearchIndexes() throws IOException {
+    return searchService.clearIndexFiles();
+  }
+
   @PostMapping(value = "/chemistry/save")
   public @ResponseBody String convert(@Valid @RequestBody SaveDTO saveDTO) throws IOException {
     searchService.saveChemicalToFile(saveDTO.chemical(), saveDTO.chemicalId());
@@ -30,4 +35,5 @@ public class SearchController {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     return searchService.search(searchDTO.chemicalSearchTerm());
   }
+
 }

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -69,7 +69,7 @@ public class SearchService {
     index.createNewFile();
   }
 
-  public String clearIndexFiles() throws IOException {
+  public void clearIndexFiles() throws IOException {
     LOGGER.info("clearing search indexes...");
 
     nonIndexedChemicals.delete();
@@ -78,7 +78,6 @@ public class SearchService {
     initFiles();
 
     LOGGER.info("... done");
-    return "Ok";
   }
 
 

--- a/src/main/java/com/researchspace/chemistry/search/SearchService.java
+++ b/src/main/java/com/researchspace/chemistry/search/SearchService.java
@@ -69,6 +69,19 @@ public class SearchService {
     index.createNewFile();
   }
 
+  public String clearIndexFiles() throws IOException {
+    LOGGER.info("clearing search indexes...");
+
+    nonIndexedChemicals.delete();
+    indexedChemicals.delete();
+    index.delete();
+    initFiles();
+
+    LOGGER.info("... done");
+    return "Ok";
+  }
+
+
   public void saveChemicalToFile(String chemical, String chemicalId) throws IOException {
     String smiles = convertService.convert(new ConvertDTO(chemical, "smiles"));
     FileWriter fileWriter = new FileWriter(nonIndexedChemicals, true);
@@ -140,4 +153,5 @@ public class SearchService {
     }
     return Collections.emptyList();
   }
+
 }

--- a/src/test/java/com/researchspace/chemistry/search/SearchControllerTest.java
+++ b/src/test/java/com/researchspace/chemistry/search/SearchControllerTest.java
@@ -1,13 +1,17 @@
 package com.researchspace.chemistry.search;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -24,6 +28,9 @@ public class SearchControllerTest {
   private static final String SEARCH_ENDPOINT = "/chemistry/search";
 
   private static final String SAVE_ENDPOINT = "/chemistry/save";
+
+  private static final String CLEAR_SEARCH_INDEXES_ENDPOINT = "/chemistry/clearSearchIndexes";
+
 
   @Test
   void whenValidSearchRequest_thenReturns200AndResult() throws Exception {
@@ -127,4 +134,18 @@ public class SearchControllerTest {
                 .content(requestWithIncorrectField))
         .andExpect(status().isBadRequest());
   }
+
+  @Test
+  void whenValidCleanSearchIndexesRequest_thenReturns200() throws Exception {
+    doNothing().when(searchService).clearIndexFiles();
+    verify(searchService, Mockito.never()).clearIndexFiles();
+
+    mockMvc
+        .perform(
+            delete(CLEAR_SEARCH_INDEXES_ENDPOINT))
+        .andExpect(status().isOk());
+
+    verify(searchService, Mockito.times(1)).clearIndexFiles();
+  }
+
 }

--- a/src/test/java/com/researchspace/chemistry/search/SearchIT.java
+++ b/src/test/java/com/researchspace/chemistry/search/SearchIT.java
@@ -1,6 +1,7 @@
 package com.researchspace.chemistry.search;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -113,6 +114,29 @@ public class SearchIT {
 
     List<String> results = searchService.search("CCO");
     assertEquals(0, results.size());
+  }
+
+  @Test
+  public void testClearingSearchIndexes() throws Exception {
+    List<String> results = searchService.search("CCC");
+    assertEquals(0, results.size());
+
+    searchService.saveChemicalToFile("CCC", "1234");
+    results = searchService.search("CC");
+    assertEquals(1, results.size());
+    assertTrue(results.contains("1234"));
+
+    // clear
+    searchService.clearIndexFiles();
+    results = searchService.search("CCC");
+    assertEquals(0, results.size());
+
+    // confirm working for newly index files again
+    searchService.saveChemicalToFile("CCC", "5678");
+    results = searchService.search("CC");
+    assertEquals(1, results.size());
+    assertFalse(results.contains("1234"));
+    assertTrue(results.contains("5678"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Adds an endpoint that, upon calling, deletes and re-creates index files.